### PR TITLE
Fix MongoDbClient bugs

### DIFF
--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -247,8 +247,10 @@ public class MongoDbClient extends DB {
             Iterator<String> keys = values.keySet().iterator();
             while (keys.hasNext()) {
                 String tmpKey = keys.next();
-                fieldsToSet.put(tmpKey, values.get(tmpKey).toArray());
-
+                // MongoDB doesn't allow modifying _id
+                if (!tmpKey.equals("_id")) {
+                    fieldsToSet.put(tmpKey, values.get(tmpKey).toArray());
+                }
             }
             u.put("$set", fieldsToSet);
             WriteResult res = collection.update(q, u, false, false,


### PR DESCRIPTION
This branch fixes two bugs in `MongoDbClient`:
- ClassCastExceptions raised due to the incorrect handling of field values returned by database queries in `read()`
- MongoExceptions raised due to attempts to update the `_id` field value in `update()`
