### PR TITLE
Check DB.update() return value in ClosedEconomyWorkload.doTransactionReadModifyWrite()

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/workloads/ClosedEconomyWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/ClosedEconomyWorkload.java
@@ -624,8 +624,10 @@ public class ClosedEconomyWorkload extends Workload {
 				secondvalues.put("field0",
 						new StringByteIterator(Integer.toString(secondamount)));
 
-				db.update(table, firstkey, firstvalues);
-				db.update(table, secondkey, secondvalues);
+				if (db.update(table, firstkey, firstvalues) != 0 ||
+				    db.update(table, secondkey, secondvalues) != 0) {
+					return false;
+				}
 
 				long en = System.currentTimeMillis();
 


### PR DESCRIPTION
The return value of `DB.update()` was previously unchecked in `ClosedEconomyWorkload.doTransactionReadModifyWrite()`, resulting in `DB.abort()` not being called when a transaction failed half-way